### PR TITLE
fix: add gap between buttons

### DIFF
--- a/src/components/tablings/ReservationModalView.vue
+++ b/src/components/tablings/ReservationModalView.vue
@@ -52,14 +52,14 @@ const props = defineProps({
           <div>40분</div>
         </div>
       </div>
-      <div class="w-full flex flex-row justify-between">
+      <div class="w-full flex flex-row justify-between gap-[10px]">
         <button
-          class="w-[162px] h-[43px] bg-secondary-100 text-white font-bold rounded-lg-xl"
+          class="w-full h-[43px] bg-secondary-100 text-white font-bold rounded-lg-xl"
           @click="handleCloseReserveModal()"
         >
           닫기
         </button>
-        <button class="w-[162px] h-[43px] bg-primary-900 text-white font-bold rounded-lg-xl">예약하기</button>
+        <button class="w-full h-[43px] bg-primary-900 text-white font-bold rounded-lg-xl">예약하기</button>
       </div>
     </div>
   </div>

--- a/src/components/tablings/SearchReservationModal.vue
+++ b/src/components/tablings/SearchReservationModal.vue
@@ -37,10 +37,10 @@ const props = defineProps({
           <div>5명</div>
         </div>
       </div>
-      <div class="w-full flex flex-row justify-between">
-        <button class="w-[162px] h-[43px] bg-secondary-100 text-white font-bold rounded-lg-xl">예약 취소</button>
+      <div class="w-full flex flex-row justify-between gap-[10px]">
+        <button class="w-full h-[43px] bg-secondary-100 text-white font-bold rounded-lg-xl">예약 취소</button>
         <button
-          class="w-[162px] h-[43px] bg-primary-900 text-white font-bold rounded-lg-xl"
+          class="w-full h-[43px] bg-primary-900 text-white font-bold rounded-lg-xl"
           @click="handleCloseSearchReserveModal()"
         >
           확인


### PR DESCRIPTION
## Issue
- 모달창 버튼 사이의 간격이 없는 오류

## Resolve
- gap을 추가하고 화면의 width가 늘어났을때를 생각해서 버튼의 width를 고정하지 않고 w-full로 줌

## Image
### before
- 모달창 버튼 사이 간격 없음
![image](https://github.com/DEV-TINO/Festino-App-FE/assets/114553010/5f2c811e-0cbf-461a-a1aa-63c5584f4a44)

### after
- 모달창 버튼 사이 간격주고 버튼 크기 변경
<img width="336" alt="image" src="https://github.com/DEV-TINO/Festino-App-FE/assets/114553010/2abeb6b3-02e2-4a89-bde0-57f49bcb0bcd">
- 화면 width가 넓어졌을 때
<img width="453" alt="image" src="https://github.com/DEV-TINO/Festino-App-FE/assets/114553010/4efbccf1-693f-40d3-bb51-8236be5a9d17">
