### PR TITLE
fix: booth infromation images scrolling error

### DIFF
--- a/src/components/booth/BoothInformation.vue
+++ b/src/components/booth/BoothInformation.vue
@@ -53,7 +53,7 @@ const getBoothIntroduceImageProps = (boothImage) => {
       >
         {{ currentIndex + 1 }} / {{ imageList.length }}
       </div>
-      <div ref="containerRef" class="snap-x overflow-x-auto w-full min-h-[340px] sm:h-[453.5px] flex rounded-3xl gap-4 border">
+      <div ref="containerRef" class="snap-x snap-mandatory overflow-x-auto w-full min-h-[340px] sm:h-[453.5px] flex rounded-3xl gap-4 border">
         <div v-for="(image, index) in imageList" :key="index" class="sanp-always snap-center min-w-full">
           <div 
             class="aspect-square w-full min-h-[340px] h-[340px] xs:h-[390px] sm:h-[453.5px] max-h-[453.5px] bg-cover bg-no-repeat"


### PR DESCRIPTION
## Docs
- [figma design templete](https://www.figma.com/file/AvPmGxteLCH1tflsiF6e8H/PLAY-TINO?type=design&node-id=0-1&mode=design&t=z1JjDqmk2r0CWs9p-0)

## Changes
- 부스 디테일 페이지 스크롤 에러

## Images
### Before
<img src="https://github.com/user-attachments/assets/dbf2cc1b-02d4-4a91-9b92-5a58f1a221b3" width="300" />

### After
<img src="https://github.com/user-attachments/assets/5fbeaf66-3fe2-4572-a7b3-f0094cff4149" width="300" />

## Check List
- [x] 부스 디테일 페이지 이미지 스크롤 중, 중간에 멈추지 않도록