### PR TITLE
fix: booth map size

### DIFF
--- a/src/components/booth/BoothMap.vue
+++ b/src/components/booth/BoothMap.vue
@@ -27,7 +27,7 @@ const markers = ref([
 const selectedMarker = ref(null);
 
 const zoomIn = () => {
-  zoomLevel.value = Math.min(zoomLevel.value + 0.1, 1.5);
+  zoomLevel.value = Math.min(zoomLevel.value + 0.1, 1.3);
 };
 
 const zoomOut = () => {
@@ -93,8 +93,8 @@ watch([zoomLevel, imageLoaded, selectBoothMenu], () => {
             :style="{
               left: `calc(${marker.left * zoomLevel}px)`,
               bottom: `calc(${marker.bottom * zoomLevel}px)`,
-              transform: `scale(${selectedMarker === index ? 1.2 : 1}) translateY(${selectedMarker === index ? -74 * zoomLevel : 0}px)`,
-              opacity: selectedMarker === index ? '1' : '0.6',
+              transform: `scale(${selectedMarker === index ? 1.2 : 1}) translateY(${selectedMarker === index ? -73 - zoomLevel : 0}px)`,
+              opacity: selectedMarker === index ? '1' : '0.75',
               width: `${selectedMarker === index ? 51 : 45 * zoomLevel}px`,
               height: `${selectedMarker === index ? 50 : 44 * zoomLevel}px`,
               zIndex: selectedMarker === index ? 2 : 1


### PR DESCRIPTION
## Docs
- [figma design templete](https://www.figma.com/file/AvPmGxteLCH1tflsiF6e8H/PLAY-TINO?type=design&node-id=0-1&mode=design&t=z1JjDqmk2r0CWs9p-0)

## Changes
- 스크린 크기가 달라져도 지도 사이즈나 마커 위치가 변경되지 않도록 변경

## Images
<img src="https://github.com/user-attachments/assets/97936550-138a-4f75-b368-d40ca55a3790" width="300" />
<img src="https://github.com/user-attachments/assets/a25a7118-ada1-41fc-bccf-9a336b40088e" width="300" />


## Check List
- [x] 스크린 크기가 달라져도 지도 사이즈나 마커가 변경되지 않도록