### PR TITLE
feat: when clicking on the map, booth marker is disabled

### DIFF
--- a/src/components/booth/BoothMap.vue
+++ b/src/components/booth/BoothMap.vue
@@ -258,6 +258,10 @@ const initializeMap = () => {
   loadDetailMap();
 }
 
+const initSelectedMarker = () => {
+  selectedMarker.value = '';
+}
+
 onMounted(() => {
   imageLoaded.value = true;
   initializeMap(); // 페이지 로드 시 호출
@@ -310,7 +314,8 @@ watchEffect(() => {
         id="map-container"
         class="relative aspect-square w-full min-h-[340px] h-[340px] xs:h-[390px] sm:h-[453.5px] max-h-[453.5px] bg-map-color border border-primary-900-light rounded-3xl overflow-auto touch-pan-x touch-pan-y"
       >
-        <div 
+        <div
+          @click="initSelectedMarker()"
           class="relative scroll-smooth"
           id="map-area"
           :style="{ 
@@ -357,7 +362,7 @@ watchEffect(() => {
                   transformOrigin: 'center bottom',
                   zIndex: `${selectedMarker === marker ? '1000' : '500'}`
                 }"
-                @click="handleMarkerClick(marker)"
+                @click.stop="handleMarkerClick(marker)"
               >
                 <div
                   v-if="zoomLevel > 1.4 && !isBoothDetail"


### PR DESCRIPTION
## Changes
- 부스 페이지에서 지도 클릭시, 기존에 선택되어 있던 마커 비활성화

## Images
![Aug-05-2024 20-29-04](https://github.com/user-attachments/assets/de25dc76-8c34-4722-8cbe-21cf145c789b)

## Check List
- [x] 지도 클릭시, 활성화 되어 있던 마커 비활성화
- [x] 다시 마커 클릭했을 때 정상적으로 다시 마커 활성화
