### PR TITLE
fix: facility detail page banner error

### DIFF
--- a/src/components/booth/DetailBanner.vue
+++ b/src/components/booth/DetailBanner.vue
@@ -21,7 +21,7 @@ const handleClickBoothDetailBackArrow = () => {
       ></div>
       <div class="absolute w-auto h-auto dynamic-top dynamic-padding">
         <div
-          v-if="booth?.adminCategory"
+          v-if="booth.adminCategory != '편의시설'"
           class="bg-gradient-to-b from-white from-50% to-primary-300 bg-clip-text text-transparent font-jalnan2 text-md xs:text-md sm:text-[19px]"
         >
           먹거리가 가득한


### PR DESCRIPTION
## Issue
- 편의시설 데이터에 adminCategory가 들어가면서 예외처리를 수정해야 하는 상황
- 편의시설 배너에 '먹거리가 가득한'이라는 서브 타이틀 예외처리 수정

## Changes
- adminCategory가 편의시설일 경우 배너에 '먹거리가 가득한'이 빠지도록 예외처리 수정

## Images
### Before
<img src="https://github.com/user-attachments/assets/225b89bf-0444-40e2-abb2-590a23471e69" width="300" />

### After
<img width="323" alt="image" src="https://github.com/user-attachments/assets/290e34ce-e180-4b9e-a65b-d9e5a2d6adb9">