### PR TITLE
fix: page scroll error

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -5,10 +5,8 @@ import { onMounted, ref } from 'vue';
 </script>
 
 <template>
-  <div class="h-lvh">
-    <RouterView />
-    <Footer class="limit-width"></Footer>
-  </div>
+  <RouterView />
+  <Footer class="limit-width"></Footer>
 </template>
 
 <style lang="css" scoped>


### PR DESCRIPTION
## Issue
- 크롬과 사파리에서 전체 페이지 길이가 처음에 주소창을 제외한 만큼만 그려지는 현상 발생

## Resolve
- 레이아웃에서 ```h-lvh``` 제거