### PR TITLE
fix : add identifiable value in notice url

### DIFF
--- a/src/components/notice/Notice.vue
+++ b/src/components/notice/Notice.vue
@@ -13,7 +13,7 @@ const props = defineProps({
 });
 
 const handleClickNotice = async (noticeId) => {
-  router.push({ name: 'notice', state: { noticeId } });
+  router.push({ path: `/notice/${noticeId}`, state: { noticeId } });
 };
 </script>
 

--- a/src/components/notice/PinNotice.vue
+++ b/src/components/notice/PinNotice.vue
@@ -13,7 +13,7 @@ const props = defineProps({
 });
 
 const handleClickNotice = async (noticeId) => {
-  router.push({ name: 'notice', state: { noticeId } });
+  router.push({ path: `/notice/${noticeId}`, state: { noticeId } });
 };
 </script>
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -57,7 +57,7 @@ const router = createRouter({
           props: true,
         },
         {
-          path: '/notice',
+          path: '/notice/:id',
           name: 'notice',
           component: NoticeView,
         },


### PR DESCRIPTION
### ISSUE
- 공지사항 페이지 url에 식별 가능한 값이 없어 모든 공지사항이 같은 URL로 취급 됨

### SOLUTION
- 각 공지사항 페이지 URL의 끝에 공지사항 ID를 넣어 식별