### PR TITLE
fix: booth image to 1:1

### DIFF
--- a/src/components/booth/BoothInformation.vue
+++ b/src/components/booth/BoothInformation.vue
@@ -116,9 +116,8 @@ const handleClickInstagram = () => {
       >
         <div v-for="(image, index) in imageList" :key="index" class="snap-start snap-always min-w-full flex-shrink-0">
           <div
-            class="scroll-smooth w-full bg-contain bg-no-repeat bg-center"
+            class="scroll-smooth w-full bg-contain bg-no-repeat bg-center aspect-w-1 aspect-h-1"
             v-bind="getBoothIntroduceImageProps(image)"
-            style="aspect-ratio: 1 / 1"
           ></div>
         </div>
       </div>


### PR DESCRIPTION
## ISSUE
- 부스 이미지가 1:1 비율로 나오지 않는 오류

## SOLUTION
- tailwind의 aspect-square가 지정되지 않아서 변경